### PR TITLE
Props delete

### DIFF
--- a/tracy/logf.go
+++ b/tracy/logf.go
@@ -15,7 +15,6 @@
 package tracy
 
 import (
-	"slices"
 	"strings"
 	"sync"
 )
@@ -76,25 +75,23 @@ func (props *Props) Set(name string, value any) {
 	props.props = append(props.props, Prop{name, value})
 }
 
-// Without returns a copy of props without any of the provided names.
-func (props *Props) All(except ...string) []Prop {
-	newProps := make([]Prop, 0, len(props.props))
-	for _, origProp := range props.props {
-		if !slices.Contains(except, origProp.Name) {
-			newProps = append(newProps, origProp)
-		}
+// Delete removes the specified keys from props.
+// This doesn't clear the data from memory, but removes its hash value so that it cannot be accessed
+// through Get/Map.
+func (props *Props) Delete(propNames ...string) {
+	for _, name := range propNames {
+		delete(props.hash, name)
 	}
-	return newProps
 }
 
-func (props *Props) AllMap(except ...string) map[string]any {
-	newProps := make(map[string]any, len(props.props))
-	for _, origProp := range props.props {
-		if !slices.Contains(except, origProp.Name) {
-			newProps[origProp.Name] = origProp.Value
-		}
+// Map returns a map of key-value pairs.
+func (props *Props) Map() map[string]any {
+	propsMap := make(map[string]any, len(props.props))
+	for _, idx := range props.hash {
+		prop := props.props[idx]
+		propsMap[prop.Name] = prop.Value
 	}
-	return newProps
+	return propsMap
 }
 
 func (props *Props) Return() {

--- a/tracy/logf/json.go
+++ b/tracy/logf/json.go
@@ -52,7 +52,7 @@ func JSONFormat(conf JSONConfig) tracy.Formatter {
 			LevelStr:  level.String(),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 			Message:   msg,
-			Props:     props.AllMap(),
+			Props:     props.Map(),
 		})
 		return string(raw)
 	}
@@ -65,7 +65,7 @@ func JSONPrettyFormat(conf JSONConfig) tracy.Formatter {
 			LevelStr:  level.String(),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 			Message:   msg,
-			Props:     props.AllMap(),
+			Props:     props.Map(),
 		}, conf.Prefix, conf.Indent)
 		return string(raw)
 	}

--- a/tracy/logf/logf_test.go
+++ b/tracy/logf/logf_test.go
@@ -17,8 +17,6 @@ package logf
 import (
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"testing"
 
 	"github.com/decentplatforms/appkit/tracy"
@@ -86,13 +84,11 @@ func TestLogger(t *testing.T) {
 	t.Run("with props", func(t *testing.T) {
 		for name, format := range formats {
 			tw := &TestWriter{}
-			iow := os.Stdout
-			w := io.MultiWriter(tw, iow)
 			conf := tracy.Config{
 				MaxLevel:     tracy.Warning,
 				DefaultLevel: tracy.Informational,
 				Format:       format,
-				Output:       w,
+				Output:       tw,
 			}
 			props := []tracy.Prop{{Name: "prop1", Value: "hello world"}, {Name: "prop2", Value: 100}, {Name: "prop3", Value: []string{"hello", "world"}}}
 			t.Run(name+" format", func(t *testing.T) {
@@ -116,7 +112,6 @@ func TestLogger(t *testing.T) {
 					}
 					tw.Last = ""
 				}
-				t.Fail()
 			})
 		}
 	})

--- a/tracy/logf/logf_test.go
+++ b/tracy/logf/logf_test.go
@@ -17,6 +17,8 @@ package logf
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/decentplatforms/appkit/tracy"
@@ -84,11 +86,13 @@ func TestLogger(t *testing.T) {
 	t.Run("with props", func(t *testing.T) {
 		for name, format := range formats {
 			tw := &TestWriter{}
+			iow := os.Stdout
+			w := io.MultiWriter(tw, iow)
 			conf := tracy.Config{
 				MaxLevel:     tracy.Warning,
 				DefaultLevel: tracy.Informational,
 				Format:       format,
-				Output:       tw,
+				Output:       w,
 			}
 			props := []tracy.Prop{{Name: "prop1", Value: "hello world"}, {Name: "prop2", Value: 100}, {Name: "prop3", Value: []string{"hello", "world"}}}
 			t.Run(name+" format", func(t *testing.T) {
@@ -112,12 +116,13 @@ func TestLogger(t *testing.T) {
 					}
 					tw.Last = ""
 				}
+				t.Fail()
 			})
 		}
 	})
 	t.Run("syslog logger", func(t *testing.T) {
 		for name, format := range syslog_formats {
-			hostname := "jnichols@debbie"
+			hostname := "testhost"
 			appname := "some-other-app"
 			msgid := "testing"
 			tw := &TestWriter{}

--- a/tracy/logf/syslog.go
+++ b/tracy/logf/syslog.go
@@ -111,7 +111,8 @@ func Syslog5424Format(conf SyslogConfig) tracy.Formatter {
 		version = 1
 		pid = os.Getpid()
 
-		spareProps := props.AllMap(SYSLOG_HOSTNAME, SYSLOG_APPNAME, SYSLOG_TAG)
+		props.Delete(SYSLOG_HOSTNAME, SYSLOG_APPNAME, SYSLOG_TAG)
+		spareProps := props.Map()
 		if len(spareProps) > 0 {
 			raw, err := json.Marshal(spareProps)
 			if err == nil {
@@ -156,7 +157,8 @@ func Syslog3164Format(conf SyslogConfig) tracy.Formatter {
 
 		pri = 8*facility + int(level)
 
-		spareProps := props.AllMap(SYSLOG_HOSTNAME, SYSLOG_APPNAME, SYSLOG_TAG)
+		props.Delete(SYSLOG_HOSTNAME, SYSLOG_APPNAME, SYSLOG_TAG)
+		spareProps := props.Map()
 		if len(spareProps) > 0 {
 			raw, err := json.Marshal(spareProps)
 			if err == nil {


### PR DESCRIPTION
Resolves #5.

Adds Props.Delete, which removes all specified keys from the Props, and additional configuration in Syslog for what to do with props. Don't figure everyone wants JSON. This differs from specific behavior cited by #5, but logging needs to be efficient and deep-copy should be avoided where possible.