### PR TITLE
Prop access

### DIFF
--- a/tracy/Makefile
+++ b/tracy/Makefile
@@ -1,13 +1,13 @@
 FORCE:
 
 test:
-	go test -coverprofile cicd/cover.out ./pkg/...
+	go test -coverprofile cicd/cover.out ./...
 
 cover: test
 	go tool cover -html cicd/cover.out
 
 bench: FORCE
-	go test -benchmem -bench=. ./pkg/...
+	go test -benchmem -bench=. ./...
 
 license:
 	addlicense -c "appkit Authors" -l apache -y 2023 .

--- a/tracy/cicd/.gitignore
+++ b/tracy/cicd/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tracy/logf.go
+++ b/tracy/logf.go
@@ -74,6 +74,15 @@ func Float[T ~float64](name string, value T) Prop {
 	}
 }
 
+// Bool returns a prop whose value is a bool.
+// T may be any type that has an underlying type of bool.
+func Bool[T ~bool](name string, value T) Prop {
+	return Prop{
+		Name:  name,
+		Value: value,
+	}
+}
+
 // Props are an ordered collection of log properties.
 type Props struct {
 	props []Prop
@@ -147,6 +156,14 @@ func GetUInt[T ~uint | ~uint64](props *Props, name string, def T) T {
 
 // GetFloat gets a named float prop with default value def.
 func GetFloat[T ~float64](props *Props, name string, def T) T {
+	if v, ok := props.Get(name).(T); ok {
+		return v
+	}
+	return def
+}
+
+// GetBool gets a named bool prop with default value def.
+func GetBool[T ~bool](props *Props, name string, def T) T {
 	if v, ok := props.Get(name).(T); ok {
 		return v
 	}

--- a/tracy/logf.go
+++ b/tracy/logf.go
@@ -15,6 +15,7 @@
 package tracy
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 )
@@ -24,11 +25,63 @@ type Prop struct {
 	Value any
 }
 
+// String returns a prop whose value is a string.
+// T may be any type that has an underlying type of string.
+//
+// If you need to use a fmt.Stringer, use tracy.Stringer.
+func String[T ~string](name string, value T) Prop {
+	return Prop{
+		Name:  name,
+		Value: value,
+	}
+}
+
+// Stringer returns a prop whose value is a string.
+// T may be any type that implements fmt.Stringer.
+func Stringer[T fmt.Stringer](name string, value T) Prop {
+	return Prop{
+		Name:  name,
+		Value: value.String(),
+	}
+}
+
+// Int returns a prop whose value is an int.
+// T may be any type that has an underlying type of int, int64, uint, or uint64.
+// This converts the value to an int64.
+func Int[T ~int | ~int64](name string, value T) Prop {
+	return Prop{
+		Name:  name,
+		Value: value,
+	}
+}
+
+// UInt returns a prop whose value is an unsigned int.
+// T may be any type that has an underlying type of uint, or uint64.
+// This converts the value to a uint64.
+func UInt[T ~uint | ~uint64](name string, value T) Prop {
+	return Prop{
+		Name:  name,
+		Value: value,
+	}
+}
+
+// Float returns a prop whose value is a float.
+// T may be any type that has an underlying type of float64.
+func Float[T ~float64](name string, value T) Prop {
+	return Prop{
+		Name:  name,
+		Value: value,
+	}
+}
+
+// Props are an ordered collection of log properties.
 type Props struct {
 	props []Prop
 	hash  map[string]int
 }
 
+// The propsPool is used to manage log properties in async contexts.
+// It keeps memory usage lower when there's a high volume of log messages.
 var propsPool = &sync.Pool{
 	New: func() any {
 		return &Props{
@@ -59,6 +112,8 @@ func NewProps(props ...Prop) *Props {
 	return newProps
 }
 
+// Get returns a named log property in the calling props.
+// If there's no matching property, returns nil instead.
 func (props *Props) Get(name string) any {
 	if idx, ok := props.hash[name]; ok && idx < len(props.props) {
 		return props.props[idx].Value
@@ -66,20 +121,52 @@ func (props *Props) Get(name string) any {
 	return nil
 }
 
-func (props *Props) Set(name string, value any) {
-	if idx, ok := props.hash[name]; ok {
-		props.props[idx].Value = value
+// GetString gets a named string prop with default value def.
+func GetString[T ~string](props *Props, name string, def T) T {
+	if v, ok := props.Get(name).(T); ok {
+		return v
+	}
+	return def
+}
+
+// GetInt gets a named int prop with default value def.
+func GetInt[T ~int | ~int64](props *Props, name string, def T) T {
+	if v, ok := props.Get(name).(T); ok {
+		return v
+	}
+	return def
+}
+
+// GetUInt gets a named uint prop with default value def.
+func GetUInt[T ~uint | ~uint64](props *Props, name string, def T) T {
+	if v, ok := props.Get(name).(T); ok {
+		return v
+	}
+	return def
+}
+
+// GetFloat gets a named float prop with default value def.
+func GetFloat[T ~float64](props *Props, name string, def T) T {
+	if v, ok := props.Get(name).(T); ok {
+		return v
+	}
+	return def
+}
+
+func (props *Props) Set(prop Prop) {
+	if idx, ok := props.hash[prop.Name]; ok {
+		props.props[idx].Value = prop.Value
 		return
 	}
-	props.hash[name] = len(props.props)
-	props.props = append(props.props, Prop{name, value})
+	props.hash[prop.Name] = len(props.props)
+	props.props = append(props.props, prop)
 }
 
 // Delete removes the specified keys from props.
 // This doesn't clear the data from memory, but removes its hash value so that it cannot be accessed
 // through Get/Map.
-func (props *Props) Delete(propNames ...string) {
-	for _, name := range propNames {
+func (props *Props) Delete(propnames ...string) {
+	for _, name := range propnames {
 		delete(props.hash, name)
 	}
 }

--- a/tracy/logf/logf_test.go
+++ b/tracy/logf/logf_test.go
@@ -17,6 +17,8 @@ package logf
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/decentplatforms/appkit/tracy"
@@ -45,6 +47,14 @@ var formats = map[string]tracy.Formatter{
 var syslog_formats = map[string]tracy.Formatter{
 	"syslog_rfc3164": Syslog3164Format(SyslogConfig{}),
 	"syslog_rfc5424": Syslog5424Format(SyslogConfig{}),
+}
+
+func testProps() []tracy.Prop {
+	return []tracy.Prop{
+		tracy.String("property", "value"),
+		tracy.Int("num1", 1),
+		tracy.Float("num2", 2.0),
+	}
 }
 
 func TestLogger(t *testing.T) {
@@ -84,13 +94,13 @@ func TestLogger(t *testing.T) {
 	t.Run("with props", func(t *testing.T) {
 		for name, format := range formats {
 			tw := &TestWriter{}
+			w := io.MultiWriter(tw, os.Stdout)
 			conf := tracy.Config{
 				MaxLevel:     tracy.Warning,
 				DefaultLevel: tracy.Informational,
 				Format:       format,
-				Output:       tw,
+				Output:       w,
 			}
-			props := []tracy.Prop{{Name: "prop1", Value: "hello world"}, {Name: "prop2", Value: 100}, {Name: "prop3", Value: []string{"hello", "world"}}}
 			t.Run(name+" format", func(t *testing.T) {
 				conf.Format = format
 				log, err := tracy.NewLogger(conf)
@@ -100,9 +110,9 @@ func TestLogger(t *testing.T) {
 				for i := tracy.MOST_SEVERE; i < tracy.LEAST_SEVERE; i++ {
 					lvl := tracy.LogLevel(i)
 					msg := fmt.Sprintf("test log at level %s", lvl)
-					log.Log(tracy.LogLevel(i), msg, props...)
+					log.Log(tracy.LogLevel(i), msg, testProps()...)
 					if i <= conf.MaxLevel {
-						if expected := format.FormatAndNormalize(lvl, msg, tracy.NewProps(props...)); tw.Last != expected {
+						if expected := format.FormatAndNormalize(lvl, msg, tracy.NewProps(testProps()...)); tw.Last != expected {
 							t.Error("wrong log at", lvl, tw.Last, expected)
 						}
 					} else {
@@ -112,6 +122,7 @@ func TestLogger(t *testing.T) {
 					}
 					tw.Last = ""
 				}
+				t.Fail()
 			})
 		}
 	})
@@ -127,7 +138,6 @@ func TestLogger(t *testing.T) {
 				Format:       format,
 				Output:       tw,
 			}
-			props := []tracy.Prop{{Name: SYSLOG_HOSTNAME, Value: hostname}, {Name: SYSLOG_APPNAME, Value: appname}, {Name: SYSLOG_TAG, Value: msgid}}
 			t.Run(name+" format", func(t *testing.T) {
 				conf.Format = format
 				log, err := tracy.NewLogger(conf)
@@ -137,9 +147,9 @@ func TestLogger(t *testing.T) {
 				for i := tracy.MOST_SEVERE; i < tracy.LEAST_SEVERE; i++ {
 					lvl := tracy.LogLevel(i)
 					msg := fmt.Sprintf("test log at level %s", lvl)
-					log.Log(tracy.LogLevel(i), msg, props...)
+					log.Log(tracy.LogLevel(i), msg, tracy.String(SYSLOG_HOSTNAME, hostname), tracy.String(SYSLOG_APPNAME, appname), tracy.String(SYSLOG_TAG, msgid))
 					if i <= conf.MaxLevel {
-						if expected := format.FormatAndNormalize(lvl, msg, tracy.NewProps(props...)); tw.Last != expected {
+						if expected := format.FormatAndNormalize(lvl, msg, tracy.NewProps(tracy.String(SYSLOG_HOSTNAME, hostname), tracy.String(SYSLOG_APPNAME, appname), tracy.String(SYSLOG_TAG, msgid))); tw.Last != expected {
 							t.Error("wrong log at", lvl, tw.Last, expected)
 						}
 					} else {

--- a/tracy/logf/logf_test.go
+++ b/tracy/logf/logf_test.go
@@ -122,7 +122,6 @@ func TestLogger(t *testing.T) {
 					}
 					tw.Last = ""
 				}
-				t.Fail()
 			})
 		}
 	})
@@ -158,7 +157,6 @@ func TestLogger(t *testing.T) {
 						}
 					}
 					tw.Last = ""
-					t.Fail()
 				}
 			})
 		}

--- a/tracy/logf/syslog.go
+++ b/tracy/logf/syslog.go
@@ -23,8 +23,6 @@ import (
 	"github.com/decentplatforms/appkit/tracy"
 )
 
-type SDParam tracy.Prop
-
 type SDElement struct {
 	Name string
 }
@@ -136,7 +134,7 @@ func Syslog5424Format(conf SyslogConfig) tracy.Formatter {
 		pid = os.Getpid()
 
 		props.Delete(SYSLOG_HOSTNAME, SYSLOG_APPNAME, SYSLOG_TAG)
-		conf.WithProps(msg, props)
+		msg = conf.WithProps(msg, props)
 
 		return fmt.Sprintf("<%d>%d %s %s %s %d %s %s %s", pri, version, timestamp, hostname, appname, pid, msgid, structured, msg)
 	}
@@ -176,7 +174,7 @@ func Syslog3164Format(conf SyslogConfig) tracy.Formatter {
 		pri = 8*facility + int(level)
 
 		props.Delete(SYSLOG_HOSTNAME, SYSLOG_APPNAME, SYSLOG_TAG)
-		conf.WithProps(msg, props)
+		msg = conf.WithProps(msg, props)
 
 		return fmt.Sprintf("<%d>%s %s %s: %s", pri, timestamp, hostname, tag, msg)
 	}

--- a/tracy/output/file_bench_test.go
+++ b/tracy/output/file_bench_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func BenchmarkFile(b *testing.B) {
-	writer, err := Open("../../dat/test.log", 100)
+	writer, err := Open("../cicd/test.log", 100)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/tracy/output/file_test.go
+++ b/tracy/output/file_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestFile(t *testing.T) {
-	writer, err := Open("../../dat/test.log", 100)
+	writer, err := Open("../cicd/test.log", 100)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR updates access to and creation of log message properties. You can now use `tracy.Type` to create a prop of Type, and `tracy.GetType` to get a prop with a default value. This is mostly a semantic distinction; you can still construct properties using the `tracy.Prop` struct for additional detail (like including an object), but you probably should not.