### PR TITLE
use kv for syslog default, syslog tests

### DIFF
--- a/tracy/Makefile
+++ b/tracy/Makefile
@@ -4,7 +4,7 @@ test:
 	go test -coverprofile cicd/cover.out ./...
 
 cover: test
-	go tool cover -html cicd/cover.out
+	go tool cover -html cicd/cover.out -o cicd/cover.html
 
 bench: FORCE
 	go test -benchmem -bench=. ./...

--- a/tracy/logf.go
+++ b/tracy/logf.go
@@ -16,6 +16,7 @@ package tracy
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -183,9 +184,18 @@ func (props *Props) Set(prop Prop) {
 // This doesn't clear the data from memory, but removes its hash value so that it cannot be accessed
 // through Get/Map.
 func (props *Props) Delete(propnames ...string) {
-	for _, name := range propnames {
-		delete(props.hash, name)
+	newProps := make([]Prop, len(props.props))
+	i := 0
+	for _, prop := range props.props {
+		if slices.Contains(propnames, prop.Name) {
+			delete(props.hash, prop.Name)
+		} else {
+			newProps[i] = prop
+			props.hash[prop.Name] = i
+			i++
+		}
 	}
+	props.props = newProps[:i]
 }
 
 // Map returns a map of key-value pairs.

--- a/tracy/logf/syslog.go
+++ b/tracy/logf/syslog.go
@@ -39,7 +39,7 @@ const (
 //   - Tag is used as MSGID in 5424
 //   - UseISO8601 only applies to RFC 3164; rfc5424 specifies RFC3339 time
 //   - You may not set Facility to 0
-//   - WithProps uses logf.SyslogJSON by default.
+//   - WithProps uses logf.SyslogKV by default.
 type SyslogConfig struct {
 	Hostname   string
 	AppName    string
@@ -60,6 +60,10 @@ func SyslogJSON(msg string, props *tracy.Props) string {
 		}
 	}
 	return msg
+}
+
+func SyslogKV(msg string, props *tracy.Props) string {
+	return msg + " " + formatProps(props, false)
 }
 
 // SyslogIgnore is an option for SyslogConfig.WithProps.
@@ -87,7 +91,7 @@ func (conf SyslogConfig) withDefaults() SyslogConfig {
 		conf.Facility = 1
 	}
 	if conf.WithProps == nil {
-		conf.WithProps = SyslogJSON
+		conf.WithProps = SyslogKV
 	}
 	return conf
 }

--- a/tracy/logf/syslog_test.go
+++ b/tracy/logf/syslog_test.go
@@ -1,0 +1,179 @@
+package logf
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/decentplatforms/appkit/tracy"
+	"github.com/decentplatforms/appkit/tracy/testhelp"
+)
+
+var syslog_formats = map[string]tracy.Formatter{
+	"syslog_rfc3164": Syslog3164Format(SyslogConfig{
+		Hostname: "test-host",
+		Tag:      "test-log",
+	}),
+	"syslog_rfc3164.json": Syslog3164Format(SyslogConfig{
+		Hostname:  "test-host",
+		Tag:       "test-log",
+		WithProps: SyslogJSON,
+	}),
+	"syslog_rfc3164.timedetail": Syslog3164Format(SyslogConfig{
+		Hostname:   "test-host",
+		Tag:        "test-log",
+		UseISO8601: true,
+	}),
+	"syslog_rfc3164.ignore": Syslog3164Format(SyslogConfig{
+		Hostname:  "test-host",
+		Tag:       "test-log",
+		WithProps: SyslogIgnore,
+	}),
+	"syslog_rfc5424": Syslog5424Format(SyslogConfig{
+		Hostname: "test-host",
+		AppName:  "test-app",
+		Tag:      "test-log",
+	}),
+}
+
+var syslog_regexes = map[string]*regexp.Regexp{
+	"syslog_rfc3164":            regexp.MustCompile(`(?P<pri><\d+>)(?P<timestamp>[A-Z][a-z]{2} [ \d]\d \d{2}:\d{2}:\d{2}) (?P<hostname>\S+) (?P<tag>[^:\s]+): (?P<message>.+)`),
+	"syslog_rfc3164.timedetail": regexp.MustCompile(`(?P<pri><\d+>)(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z) (?P<hostname>\S+) (?P<tag>[^:\s]+): (?P<message>.+)`),
+	"syslog_rfc5424":            regexp.MustCompile(`(?P<pri><\d+>)(?P<version>\d+) (?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[\+-]\d{2}:\d{2})) (?P<hostname>\S+) (?P<appname>\S+) (?P<pid>\d+) (?P<msgid>\S+) (?P<structured>\S+) (?P<message>.+)`),
+}
+
+var syslog_expects = map[string]testhelp.ResultsMap{
+	"syslog_rfc3164": {
+		"pri":      "<14>",
+		"hostname": "test-host",
+		"tag":      "test-log",
+		"message":  `test log detail="testing format using regex"`,
+	},
+	"syslog_rfc3164.json": {
+		"pri":      "<14>",
+		"hostname": "test-host",
+		"tag":      "test-log",
+		"message":  `test log {"detail":"testing format using regex"}`,
+	},
+	"syslog_rfc3164.ignore": {
+		"pri":      "<14>",
+		"hostname": "test-host",
+		"tag":      "test-log",
+		"message":  `test log`,
+	},
+	"syslog_rfc5424": {
+		"pri":        "<14>",
+		"version":    "1",
+		"hostname":   "test-host",
+		"appname":    "test-app",
+		"msgid":      "test-log",
+		"structured": "-",
+		"message":    `test log detail="testing format using regex"`,
+	},
+}
+
+var syslog_custom_props = map[string][]tracy.Prop{
+	"syslog_rfc3164": {tracy.String(SYSLOG_HOSTNAME, "custom-host"), tracy.String(SYSLOG_TAG, "custom-log")},
+	"syslog_rfc5424": {tracy.String(SYSLOG_HOSTNAME, "custom-host"), tracy.String(SYSLOG_APPNAME, "custom-app"), tracy.String(SYSLOG_TAG, "custom-log")},
+}
+
+var syslog_custom_expects = map[string]testhelp.ResultsMap{
+	"syslog_rfc3164": {
+		"pri":      "<14>",
+		"hostname": "custom-host",
+		"tag":      "custom-log",
+		"message":  `test log detail="testing with custom props"`,
+	},
+	"syslog_rfc3164.json": {
+		"pri":      "<14>",
+		"hostname": "custom-host",
+		"tag":      "custom-log",
+		"message":  `test log {"detail":"testing with custom props"}`,
+	},
+	"syslog_rfc3164.ignore": {
+		"pri":      "<14>",
+		"hostname": "custom-host",
+		"tag":      "custom-log",
+		"message":  `test log`,
+	},
+	"syslog_rfc5424": {
+		"pri":        "<14>",
+		"version":    "1",
+		"hostname":   "custom-host",
+		"appname":    "custom-app",
+		"msgid":      "custom-log",
+		"structured": "-",
+		"message":    `test log detail="testing with custom props"`,
+	},
+}
+
+func results(msg, format string) (map[string]string, error) {
+	regex := testhelp.GetTestOption(syslog_regexes, format, nil)
+	matches := regex.FindStringSubmatch(msg)
+	if matches == nil {
+		fmt.Println(msg)
+		return nil, errors.New("message didn't match format " + format)
+	}
+	result := make(map[string]string)
+	for i, name := range regex.SubexpNames() {
+		result[name] = matches[i]
+	}
+	return result, nil
+}
+
+func TestSyslog(t *testing.T) {
+	for name, format := range syslog_formats {
+		t.Run(name, func(t *testing.T) {
+			tw := &TestWriter{}
+			conf := tracy.Config{
+				MaxLevel: tracy.Informational,
+				Format:   format,
+				Output:   tw,
+			}
+			log, err := tracy.NewLogger(conf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = log.Log(tracy.Informational, "test log", tracy.String("detail", "testing format using regex"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			res, err := results(tw.Last, name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wanted := testhelp.GetTestOption(syslog_expects, name, nil)
+			err = testhelp.ValidateResults(res, wanted)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+		t.Run(name+"-custom", func(t *testing.T) {
+			tw := &TestWriter{}
+			conf := tracy.Config{
+				MaxLevel: tracy.Informational,
+				Format:   format,
+				Output:   tw,
+			}
+			log, err := tracy.NewLogger(conf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			props := append(testhelp.GetTestOption(syslog_custom_props, name, nil), tracy.String("detail", "testing with custom props"))
+			err = log.Log(tracy.Informational, "test log", props...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res, err := results(tw.Last, name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wanted := testhelp.GetTestOption(syslog_custom_expects, name, nil)
+			err = testhelp.ValidateResults(res, wanted)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/tracy/testhelp/testhelp.go
+++ b/tracy/testhelp/testhelp.go
@@ -1,0 +1,28 @@
+package testhelp
+
+import (
+	"strings"
+)
+
+// MapOptions maps test option keys to values.
+// Keys are strings separated by . symbols, denoting more
+// specific options. When using GetTestOption(TestOptionMap[T], key), the most specific
+// match is chosen, so a query for a.b.c will match a.b if a.b.c does not exist.
+// If no key matches, returns def.
+type TestOptionMap[T any] map[string]T
+
+// GetTestOption gets an option from a map[string]T (TestOptionMap[T]).
+// Keys are strings separated by . symbols, denoting more
+// specific options. When using GetTestOption(TestOptionMap[T], key), the most specific
+// match is chosen, so a query for a.b.c will match a.b if a.b.c does not exist.
+// If no key matches, returns def.
+func GetTestOption[T any](tom TestOptionMap[T], key string, def T) T {
+	toks := strings.Split(key, ".")
+	for i := len(toks); i > 0; i-- {
+		subkey := strings.Join(toks[:i], ".")
+		if v, ok := tom[subkey]; ok {
+			return v
+		}
+	}
+	return def
+}

--- a/tracy/testhelp/validate.go
+++ b/tracy/testhelp/validate.go
@@ -1,0 +1,16 @@
+package testhelp
+
+import "fmt"
+
+type ResultsMap map[string]string
+
+func ValidateResults(res, wanted ResultsMap) error {
+	for k, v := range wanted {
+		if rv, ok := res[k]; !ok {
+			return fmt.Errorf("result missing key %s", k)
+		} else if rv != v {
+			return fmt.Errorf("wanted '%s' for result key %s, got '%s'", v, k, res[k])
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR implements a `testhelp` package that helps configure complex tests, like the new ones for syslog! The main `logf` test file still covers the basic case (log format is deterministic), and syslog_test covers actual log output using regex.